### PR TITLE
fix: Update docker configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,3 @@ services:
 
   backend:
     build: service
-    environment:
-      - REDIS_HOST=redis
-
-  redis:
-    image: redis:6.0.9
-

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -7,9 +7,7 @@ RUN pip install -r requirements.txt
 
 # Explicitly copy the file so that docker will raise an error if the
 # file doesn't exist
-COPY fbConfigs.json fbConfigs_test.json /app/
+COPY fbConfigs.json environ.json /app/
 COPY . /app/
-
-RUN pytest
 
 CMD gunicorn -w $(nproc) -b 0.0.0.0:8000 app:app

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -13,7 +13,6 @@ ENV REACT_APP_API_SERVER ${API_SERVER}
 COPY .env /build/
 COPY . /build/
 
-RUN npm run test-all
 RUN npm run build
 
 FROM nginx:1.19.4


### PR DESCRIPTION
tests no longer run when building images because they are already handled by CI